### PR TITLE
Removed pagination from listcommands - print one long message instead

### DIFF
--- a/source/commands.js
+++ b/source/commands.js
@@ -257,31 +257,19 @@ var partition = function ( list, maxSize ) {
 
 return function ( args ) {
 	var commands = Object.keys( bot.commands ),
-		pagination = ' (page {0}/{1})',
 		user_name = args.get( 'user_name' ),
 		// 500 is the max, -2 for @ and space.
-		maxSize = 498 - pagination.length - user_name.length,
+		maxSize = 498 - user_name.length,
 		//TODO: only call this when commands were learned/forgotten since last
-		partitioned = partition( commands, maxSize ),
+		partitioned = partition( commands, maxSize );
+    
+    var lines = [];
+    for (var i = 0; i < partitioned.length; i++) {
+        lines.push(partitioned[i].join(', '));
+    }
+    var ret = lines.join('\n');
 
-		valid = /^(\d+|$)/.test( args.content ),
-		page = Number( args.content ) || 0;
-		
-		if(page > 0)
-			page--;
-
-	if ( page >= partitioned.length || !valid ) {
-		return args.codify( [
-			'StackOverflow: Could not access page.',
-			'IndexError: index out of range',
-			'java.lang.IndexOutOfBoundsException',
-			'IndexOutOfRangeException'
-		].random() );
-	}
-
-	var ret = partitioned[ page ].join( ', ' );
-
-	return ret + pagination.supplant( (page + 1), partitioned.length );
+	return ret;
 };
 })();
 


### PR DESCRIPTION
By sending a multiline message, we can avoid the ling length limitation entirely - removing the need for pagination.
