### PR TITLE
Replace Zirak with allquixotic where appropriate

### DIFF
--- a/source/adapter.js
+++ b/source/adapter.js
@@ -556,7 +556,7 @@ var output = {
                 console.error( xhr );
                 output.add(
                     'Error ' + xhr.status + ' occured, I will call the maid ' +
-                    ' (@Zirak)' );
+                    ' (@allquixotic)' );
             }
             else {
                 output.total += 1;

--- a/source/eval.js
+++ b/source/eval.js
@@ -97,7 +97,7 @@ exports.prettyEval = function ( code, arg, cb ) {
         if ( answer === undefined ) {
             return 'Malformed output from web-worker. If you weren\'t just ' +
                 'fooling around trying to break me, raise an issue or contact ' +
-                'Zirak';
+                'allquixotic';
         }
 
         result = snipAndCodify( answer );


### PR DESCRIPTION
There are a few places in the bot's output where the username "Zirak" is hard-coded. These commits replace them with "allquixotic" so that you get properly notified in the event the bot encounters errors like HTTP 404.